### PR TITLE
courses/java: change json format in XML-&-JSON-Data_Formats

### DIFF
--- a/docs/java/XML-&-JSON-Data-Formats.md
+++ b/docs/java/XML-&-JSON-Data-Formats.md
@@ -39,8 +39,8 @@ java -jar messagepreview.jar -type json message.json --printAverageStats
 
 където message.json: 
 
-```text
-[{firstName: “John”, lastName: “Smith”, age: 34},{firstName: “John”, lastName: “Smith”, age: 34},{firstName: “John”, lastName: “Smith”, age: 34},{firstName: “John”, lastName: “Smith”, age: 34},{firstName: “John”, lastName: “Smith”, age: 34},{firstName: “John”, lastName: “Smith”, age: 34},{firstName: “John”, lastName: “Smith”, age: 34}]
+```javascript
+{"personList":[{"firstName": "John", "lastName": "Smith", age: 34},{"firstName": "John", "lastName": "Smith", age: 34},{"firstName": "John", "lastName": "Smith", age: 34},{"firstName": "John", "lastName": "Smith", age: 34},{"firstName": "John", "lastName": "Smith", age: 34},{"firstName": "John", "lastName": "Smith", age: 34},{"firstName": "John", "lastName": "Smith", age: 34}]}
 ```
 
 a резултатът Ðµ статистически данни за обектите, който се печата в конзолата 


### PR DESCRIPTION
Changed the json format in the last task to include a higher level element that contains the list of people  and added quotation marks so that gson will accept it as proper json.